### PR TITLE
Surviving nuclear fallout in Ohio

### DIFF
--- a/2024-01-02_Ohio_Surviving_nuclear_fallout.md
+++ b/2024-01-02_Ohio_Surviving_nuclear_fallout.md
@@ -1,0 +1,5 @@
+# Surviving nuclear fallout
+- In Ohio
+- On 2024-01-02
+
+Typical Thursday in Ohio.


### PR DESCRIPTION
Surviving nuclear fallout in Ohio (#56) on 2024-01-02!
Typical Thursday in Ohio.